### PR TITLE
인입된 요청 Key-Value 를 인접 노드에 라우팅하는 API 구현

### DIFF
--- a/key-value-managed-proxy-server/build.gradle.kts
+++ b/key-value-managed-proxy-server/build.gradle.kts
@@ -12,5 +12,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
+    implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/config/KeyValueProxyConfig.kt
+++ b/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/config/KeyValueProxyConfig.kt
@@ -1,0 +1,18 @@
+package com.tommy.proxy.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
+import org.springframework.web.client.RestTemplate
+
+@Configuration
+class KeyValueProxyConfig {
+
+    @Bean
+    fun restTemplate(): RestTemplate {
+        val factory = HttpComponentsClientHttpRequestFactory()
+        factory.setConnectTimeout(5000)
+
+        return RestTemplate(factory)
+    }
+}

--- a/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/controllers/KeyValueProxyController.kt
+++ b/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/controllers/KeyValueProxyController.kt
@@ -1,0 +1,25 @@
+package com.tommy.proxy.controllers
+
+import com.tommy.proxy.dtos.KeyValueSaveRequest
+import com.tommy.proxy.dtos.KeyValueSaveResponse
+import com.tommy.proxy.services.KeyValueProxyService
+import com.tommy.proxy.utils.IpUtil
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class KeyValueProxyController(
+    private val keyValueProxyService: KeyValueProxyService,
+) {
+
+    @PostMapping("/")
+    fun save(
+        @RequestBody keyValueSaveRequest: KeyValueSaveRequest,
+        request: HttpServletRequest,
+    ): KeyValueSaveResponse {
+        val clientIp = IpUtil.getClientIp(request)
+        return keyValueProxyService.put(clientIp, keyValueSaveRequest)
+    }
+}

--- a/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/dtos/KeyValueSaveRequest.kt
+++ b/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/dtos/KeyValueSaveRequest.kt
@@ -1,0 +1,6 @@
+package com.tommy.proxy.dtos
+
+data class KeyValueSaveRequest(
+    val key: String,
+    val value: Any,
+)

--- a/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/dtos/KeyValueSaveResponse.kt
+++ b/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/dtos/KeyValueSaveResponse.kt
@@ -1,0 +1,5 @@
+package com.tommy.proxy.dtos
+
+data class KeyValueSaveResponse(
+    val key: String,
+)

--- a/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/services/KeyValueProxyService.kt
+++ b/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/services/KeyValueProxyService.kt
@@ -1,0 +1,54 @@
+package com.tommy.proxy.services
+
+import com.tommy.proxy.consistenthashing.ConsistentHashRouter
+import com.tommy.proxy.consistenthashing.node.Instance
+import com.tommy.proxy.dtos.KeyValueSaveRequest
+import com.tommy.proxy.dtos.KeyValueSaveResponse
+import mu.KotlinLogging
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestTemplate
+
+@Service
+class KeyValueProxyService(
+    private val restTemplate: RestTemplate,
+) {
+    private val logger = KotlinLogging.logger { }
+
+    fun put(requestIP: String, keyValueSaveRequest: KeyValueSaveRequest): KeyValueSaveResponse {
+        val consistentHashRouter = ConsistentHashRouter(nodes, VIRTUAL_NODE_COUNT)
+        val instance = consistentHashRouter.routeNode(requestIP) ?: throw RuntimeException()
+
+        val nodeIp = instance.getKey()
+
+        return try {
+            val headers = HttpHeaders()
+            headers.contentType = MediaType.APPLICATION_JSON
+
+            val responseEntity = restTemplate.postForEntity(
+                nodeIp,
+                HttpEntity(keyValueSaveRequest, headers),
+                KeyValueSaveResponse::class.java,
+            )
+
+            responseEntity.body!!
+        } catch (e: Exception) {
+            logger.error { e.message }
+            throw RuntimeException(e.message)
+        }
+    }
+
+    companion object {
+        private const val VIRTUAL_NODE_COUNT = 10
+
+        // TODO: 외부 인스턴스를 주입하도록 변경
+        private val node1 = Instance("127.0.0.1", 80)
+        private val node2 = Instance("127.0.0.2", 80)
+        private val node3 = Instance("127.0.0.3", 80)
+        private val node4 = Instance("127.0.0.4", 80)
+
+        private val nodes = listOf(node1, node2, node3, node4)
+    }
+}

--- a/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/utils/IpUtil.kt
+++ b/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/utils/IpUtil.kt
@@ -1,0 +1,45 @@
+package com.tommy.proxy.utils
+
+import jakarta.servlet.http.HttpServletRequest
+
+object IpUtil {
+
+    private val IP_HEADER_CANDIDATES = arrayOf(
+        "Proxy-Client-IP",
+        "WL-Proxy-Client-IP",
+        "HTTP_X_FORWARDED_FOR",
+        "HTTP_X_FORWARDED",
+        "HTTP_X_CLUSTER_CLIENT_IP",
+        "HTTP_CLIENT_IP",
+        "HTTP_FORWARDED_FOR",
+        "HTTP_FORWARDED",
+        "HTTP_VIA",
+        "REMOTE_ADDR",
+    )
+
+    fun getClientIp(request: HttpServletRequest): String {
+        var ip = getIpByXForwardedFor(request)
+
+        for (ipHeader in IP_HEADER_CANDIDATES) {
+            ip = request.getHeader(ipHeader)
+
+            if (!invalidIp(ip)) {
+                return ip
+            }
+        }
+        return ip
+    }
+
+    private fun getIpByXForwardedFor(request: HttpServletRequest): String {
+        var ip = request.getHeader("X-Forwarded-For")
+
+        if (ip.contains(",")) {
+            ip = ip.split(",").first()
+        }
+        return ip
+    }
+
+    private fun invalidIp(ip: String?): Boolean {
+        return ip.isNullOrEmpty() || "unknown".equals(ip, ignoreCase = true)
+    }
+}


### PR DESCRIPTION
work items: #9