### PR TITLE
API 요청 기술 WebClient로 변경

### DIFF
--- a/key-value-managed-proxy-server/build.gradle.kts
+++ b/key-value-managed-proxy-server/build.gradle.kts
@@ -11,6 +11,7 @@ tasks.getByPath("jar").enabled = true
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
 
     implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
 

--- a/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/config/KeyValueProxyConfig.kt
+++ b/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/config/KeyValueProxyConfig.kt
@@ -1,18 +1,35 @@
 package com.tommy.proxy.config
 
+import io.netty.channel.ChannelOption
+import io.netty.handler.timeout.ReadTimeoutHandler
+import io.netty.handler.timeout.WriteTimeoutHandler
+import java.time.Duration
+import java.util.concurrent.TimeUnit
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
-import org.springframework.web.client.RestTemplate
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.netty.http.client.HttpClient
 
 @Configuration
 class KeyValueProxyConfig {
 
     @Bean
-    fun restTemplate(): RestTemplate {
-        val factory = HttpComponentsClientHttpRequestFactory()
-        factory.setConnectTimeout(5000)
+    fun webClient(): WebClient {
+        val httpClient = HttpClient.create()
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
+            .responseTimeout(Duration.ofMillis(5000L))
+            .doOnConnected { connection ->
+                connection
+                    .addHandlerLast(ReadTimeoutHandler(30, TimeUnit.MILLISECONDS))
+                    .addHandlerLast(WriteTimeoutHandler(30, TimeUnit.MILLISECONDS))
+            }
 
-        return RestTemplate(factory)
+        return WebClient.builder()
+            .clientConnector(ReactorClientHttpConnector(httpClient))
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .build()
     }
 }


### PR DESCRIPTION
* Worker 노드에 데이터 동기화 하는 부분을 Async-Nonblocking 으로 사용하기 위해 HTTP API 통긴 기술을 WebClient 로 변경한다.

work items: #11