### PR TITLE
라우팅 구조 개선

### DIFF
--- a/key-value-managed-proxy-server/build.gradle.kts
+++ b/key-value-managed-proxy-server/build.gradle.kts
@@ -19,4 +19,5 @@ dependencies {
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("com.ninja-squad:springmockk:4.0.2")
 }

--- a/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/config/KeyValueProxyConfig.kt
+++ b/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/config/KeyValueProxyConfig.kt
@@ -1,9 +1,11 @@
 package com.tommy.proxy.config
 
+import java.time.Duration
 import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
+import org.springframework.http.converter.StringHttpMessageConverter
 import org.springframework.web.client.RestTemplate
 
 @Configuration
@@ -11,10 +13,11 @@ import org.springframework.web.client.RestTemplate
 class KeyValueProxyConfig {
 
     @Bean
-    fun restTemplate(): RestTemplate {
-        val factory = HttpComponentsClientHttpRequestFactory()
-        factory.setConnectTimeout(5000)
-
-        return RestTemplate(factory)
+    fun restTemplate(restTemplateBuilder: RestTemplateBuilder): RestTemplate? {
+        return restTemplateBuilder
+            .setConnectTimeout(Duration.ofMillis(5000))
+            .setReadTimeout(Duration.ofMillis(5000))
+            .additionalMessageConverters(StringHttpMessageConverter(Charsets.UTF_8))
+            .build()
     }
 }

--- a/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/consistenthashing/hash/MurmurHash3.kt
+++ b/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/consistenthashing/hash/MurmurHash3.kt
@@ -9,7 +9,7 @@ class MurmurHash3 : HashFunction {
 
     override fun doHash(key: String, seed: Int?): Int {
         return Hashing
-            .murmur3_32_fixed(seed ?: generateMurmurHash3Seed())
+            .murmur3_32_fixed(seed ?: generateMurmurHash3Seed()) // seed 가 null 이면 Random Seed 를 생성하여 Hashing 한다.
             .hashString(key, Charsets.UTF_8)
             .asInt()
     }

--- a/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/consistenthashing/hash/MurmurHash3.kt
+++ b/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/consistenthashing/hash/MurmurHash3.kt
@@ -2,7 +2,9 @@ package com.tommy.proxy.consistenthashing.hash
 
 import com.google.common.hash.Hashing
 import kotlin.random.Random
+import org.springframework.stereotype.Component
 
+@Component
 class MurmurHash3 : HashFunction {
 
     override fun doHash(key: String, seed: Int?): Int {

--- a/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/consistenthashing/node/VirtualNode.kt
+++ b/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/consistenthashing/node/VirtualNode.kt
@@ -12,4 +12,8 @@ class VirtualNode<T : Node>(
     fun isVirtualNodeOf(physicalNode: T): Boolean {
         return this.physicalNode.getKey() == physicalNode.getKey()
     }
+
+    override fun toString(): String {
+        return "VirtualNode(physicalNode=$physicalNode, virtualIndex=$virtualIndex)"
+    }
 }

--- a/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/services/KeyValueProxyRunner.kt
+++ b/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/services/KeyValueProxyRunner.kt
@@ -1,0 +1,20 @@
+package com.tommy.proxy.services
+
+import com.tommy.proxy.consistenthashing.ConsistentHashRouter
+import mu.KotlinLogging
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.stereotype.Component
+
+@Component
+class KeyValueProxyRunner(
+    val consistentHashRouter: ConsistentHashRouter,
+) : ApplicationRunner {
+
+    private val logger = KotlinLogging.logger { }
+
+    override fun run(args: ApplicationArguments?) {
+        consistentHashRouter.initNodes()
+        logger.info { "consistentHashRouter init nodes, hashring Size: ${consistentHashRouter.getHashRingSize()}" }
+    }
+}

--- a/key-value-managed-proxy-server/src/test/kotlin/com/tommy/proxy/consistenthashing/ConsistentHashRouterTest.kt
+++ b/key-value-managed-proxy-server/src/test/kotlin/com/tommy/proxy/consistenthashing/ConsistentHashRouterTest.kt
@@ -1,32 +1,49 @@
 package com.tommy.proxy.consistenthashing
 
+import com.tommy.proxy.config.KeyValueRoutesProperties
 import com.tommy.proxy.consistenthashing.hash.MurmurHash3
 import com.tommy.proxy.consistenthashing.node.Instance
+import io.mockk.junit5.MockKExtension
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 
+@ExtendWith(MockKExtension::class)
 class ConsistentHashRouterTest {
+
+    private val nodes = listOf(
+        "http://localhost:8081",
+        "http://localhost:8082",
+        "http://localhost:8083",
+        "http://localhost:8084",
+    )
+
+    private val sut: ConsistentHashRouter by lazy {
+        ConsistentHashRouter(
+            virtualNodeCount = 10,
+            keyValueRoutesProperties = KeyValueRoutesProperties(nodes = nodes),
+            hashFunction = MurmurHash3(),
+        )
+    }
+
+    @BeforeEach
+    fun setUp() {
+        sut.initNodes(0)
+    }
 
     @Test
     @DisplayName("안정 해시 초기화")
     fun `init consistent hash router`() {
         // Arrange
-        val virtualNodeCount = 10
-        val node1 = Instance("http://127.0.0.1:8080")
-        val node2 = Instance("http://127.0.0.2:8080")
-        val node3 = Instance("http://127.0.0.3:8080")
-        val node4 = Instance("http://127.0.0.4:8080")
 
         // Act
-        val actual = ConsistentHashRouter(
-            physicalNodes = listOf(node1, node2, node3, node4),
-            virtualNodeCount = virtualNodeCount,
-            hashFunction = MurmurHash3(),
-        )
+        val actual = sut
 
         // Assert
         assertThat(actual.getHashRingSize()).isEqualTo(40)
+        assertThat(actual.hashFunction).isInstanceOf(MurmurHash3::class.java)
     }
 
     @Test
@@ -34,44 +51,43 @@ class ConsistentHashRouterTest {
     fun `add node of consistent hash`() {
         // Arrange
         val virtualNodeCount = 10
-        val node1 = Instance("http://127.0.0.1:8080")
-        val node2 = Instance("http://127.0.0.2:8080")
-        val node3 = Instance("http://127.0.0.3:8080")
-        val node4 = Instance("http://127.0.0.4:8080")
-
-        val sut = ConsistentHashRouter(
-            physicalNodes = listOf(node1, node2, node3),
-            virtualNodeCount = virtualNodeCount,
-            hashFunction = MurmurHash3(),
-        )
+        val targetPhysicalNode = Instance("http://localhost:8085")
 
         // Act
-        sut.addNode(node4, 10)
+        sut.addNode(targetPhysicalNode, virtualNodeCount)
 
         // Assert
-        assertThat(sut.getHashRingSize()).isEqualTo(40)
+        assertThat(sut.getHashRingSize()).isEqualTo(50)
     }
 
     @Test
     @DisplayName("안정해시 해시링에 노드 제거")
     fun `remove node of consistent hash`() {
         // Arrange
-        val virtualNodeCount = 10
-        val node1 = Instance("http://127.0.0.1:8080")
-        val node2 = Instance("http://127.0.0.2:8080")
-        val node3 = Instance("http://127.0.0.3:8080")
-        val node4 = Instance("http://127.0.0.4:8080")
-
-        val sut = ConsistentHashRouter(
-            physicalNodes = listOf(node1, node2, node3, node4),
-            virtualNodeCount = virtualNodeCount,
-            hashFunction = MurmurHash3(),
-        )
+        val targetPhysicalNode = Instance("http://localhost:8083")
 
         // Act
-        sut.removeNode(node4)
+        sut.removeNode(targetPhysicalNode)
 
         // Assert
         assertThat(sut.getHashRingSize()).isEqualTo(30)
+    }
+
+    @Test
+    @DisplayName("요청으로 인입된 Key 를 해싱하여 해시링의 가장 근접한 노드로 Routing")
+    fun `get route node of consistent hash`() {
+        // Arrange
+        val key = "80a53953-3560-45f0-97f7-384155ff0d06"
+        val seed = 0
+
+        // Act
+        val hashedKey = sut.hashFunction.doHash(key, seed)
+        val actual = sut.routeNode(hashedKey)
+
+        // Assert
+        // hashedKey: 714878469
+        // 가장 가까운 노드의 hash 값: 860206175
+        // 가장 가까운 노드 정보: VirtualNode(physicalNode=http://localhost:8082, virtualIndex=4)
+        assertThat(actual.getKey()).isEqualTo("http://localhost:8082")
     }
 }

--- a/key-value-managed-proxy-server/src/test/resources/application-test.yml
+++ b/key-value-managed-proxy-server/src/test/resources/application-test.yml
@@ -1,6 +1,3 @@
-server:
-  port: 8080
-
 key-value:
   virtual-node-count: 10
   routes:


### PR DESCRIPTION
### MurmurHash3 Bean 으로 지정
### restTemplate 설정 변경
### virtual node count 를 yml 에서 정의하도록 변경
* test profile 추가 설정
### ConsistentHashRouter 구조 변경
* ConsistentHashRouter 를 Bean 으로 등록하여 Spring의 Bean Lifecycle 을 따르도록 한다.
* virtualNodeCount 는 로직에서 넣어줄 필요가 없다. config file 에서 주입하여 넣어주도록 한다.
* Discovery 역할을 현재는 config file 로 정적으로 구성하고 있다.  해당 기능을 ConsistentHashRouter 에서 관리하도록 하여 Service 에서의 주입 로직 중복을 제거한다.
* hashFunction 을 Bean 을 주입하도록 한다.
* 테스트 가능한 구조를 위해 객체 생성 시 Node 초기화가 아닌 별도의 메서드로 분리한다.
* 테스트 가능한 구조를 위해 seed 를 의존성 주입하도록 개선한다.
  * 테스트 시에는 0으로 정적인 seed 값을 구성하도록 한다.
  * 런타임 시에는 MurmurHash3 에서 Random seed 값을 구성하도록 한다.
* Exception 추가 정의
* 테스트코드 개선
### KeyValueProxyService 구조 변경
* ConsistentHashRouter 의 변경된 구조를 반영한다.
* Hashing 을 외부에서 하여 주입하도록 로직 개선.
### KeyValueProxyRunner 구현
* Application 이 실행 시 Consistent Hashing 을 초기화하도록 한다.
* initNodes 에서 seed 값을 null 로 전달할 경우에 random seed 를 생성하도록 한다.

work items: https://github.com/LimHanGyeol/distributed-key-value-store/issues/23