### PR TITLE
장애 상태 감지 기능 개선

### DIFF
--- a/key-value-store-application/src/main/kotlin/com/tommy/keyvaluestore/configs/KeyValueStoreConfig.kt
+++ b/key-value-store-application/src/main/kotlin/com/tommy/keyvaluestore/configs/KeyValueStoreConfig.kt
@@ -1,8 +1,18 @@
 package com.tommy.keyvaluestore.configs
 
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.EnableScheduling
+import java.net.InetAddress
 
-@EnableScheduling
 @Configuration
-class KeyValueStoreConfig
+@EnableScheduling
+class KeyValueStoreConfig {
+
+    @Bean
+    fun hostAddress(@Value("\${server.port}") port: Int): String {
+        val hostIp = InetAddress.getLocalHost().hostAddress
+        return "$hostIp:$port"
+    }
+}

--- a/key-value-store-application/src/main/kotlin/com/tommy/keyvaluestore/dtos/FailureNode.kt
+++ b/key-value-store-application/src/main/kotlin/com/tommy/keyvaluestore/dtos/FailureNode.kt
@@ -1,0 +1,6 @@
+package com.tommy.keyvaluestore.dtos
+
+data class FailureNode(
+    val address: String,
+    val failureNodeCount: Int,
+)

--- a/key-value-store-application/src/test/kotlin/com/tommy/keyvaluestore/schedules/FailureDetectionScheduleServiceTest.kt
+++ b/key-value-store-application/src/test/kotlin/com/tommy/keyvaluestore/schedules/FailureDetectionScheduleServiceTest.kt
@@ -1,0 +1,46 @@
+package com.tommy.keyvaluestore.schedules
+
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verifyAll
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+
+@ExtendWith(MockKExtension::class)
+class FailureDetectionScheduleServiceTest {
+
+    private val redisTemplate: StringRedisTemplate = mockk(relaxed = true)
+    private val sut = FailureDetectionScheduleService("127.0.0.1:8080", redisTemplate)
+
+    @Test
+    @DisplayName("정해진 크론식 시간주기로 노드의 HeartBeat 를 계산하여 장애 감지를 한다.")
+    fun `sut should update heartBeat count when at fixed times`() {
+        // Arrange
+        val redisKey = "node:${sut.hostAddress}"
+        val heartBeatCount = 1L
+
+        val valueOperations: ValueOperations<String, String> = redisTemplate.opsForValue()
+
+        every { valueOperations.get(redisKey) } returns "0"
+        every { valueOperations.increment(any()) } returns heartBeatCount
+        every { valueOperations.set(redisKey, heartBeatCount.toString()) } returns Unit
+
+        every { valueOperations.operations.keys("node*") } returns setOf(redisKey)
+        every { redisTemplate.opsForValue().get(redisKey) } returns heartBeatCount.toString()
+
+        // Act
+        sut.execute()
+
+        // Assert
+        verifyAll {
+            valueOperations.get("node:${sut.hostAddress}")
+            valueOperations.increment("node:${sut.hostAddress}")
+            valueOperations.set("node:${sut.hostAddress}", any())
+            valueOperations.operations.keys("node*")
+        }
+    }
+}


### PR DESCRIPTION
* HealthCheck 를 하고 해당 Count 를 하는 로직 이후 개선
* 연관된 노드들의 RedisKey 를 가져온 후 HeartBeatCount 를 계산한다.
* 장애 감지 횟수가 2 이상일 경우 Proxy Server 에게 장애 처리를 하는 API 를 호출하도록 한다.

work items: #29