### PR TITLE
장애가 발생한 노드의 virtualnode 를 삭제하는 기능 구현

### DIFF
--- a/key-value-managed-proxy-server/build.gradle.kts
+++ b/key-value-managed-proxy-server/build.gradle.kts
@@ -11,7 +11,7 @@ tasks.getByPath("jar").enabled = true
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-    implementation("org.springframework.boot:spring-boot-starter-webflux")
+    implementation("org.redisson:redisson-spring-boot-starter:3.20.1")
 
     implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
     implementation("com.google.guava:guava:31.1-jre")

--- a/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/consistenthashing/ConsistentHashRouter.kt
+++ b/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/consistenthashing/ConsistentHashRouter.kt
@@ -30,7 +30,7 @@ class ConsistentHashRouter(
         if (virtualNodeCount < 0) {
             throw IllegalArgumentException("invalid virtual node counts: $virtualNodeCount")
         }
-        val existingReplicas = getExistingVirtualIndex(physicalNode)
+        val existingReplicas = getExistingVirtualNodeCount(physicalNode)
         for (i in 0 until virtualNodeCount) {
             val virtualNode = VirtualNode(physicalNode, i + existingReplicas)
             val hashedKey = hashFunction.doHash(virtualNode.getKey(), seed)
@@ -91,8 +91,7 @@ class ConsistentHashRouter(
         throw IllegalStateException("no matching virtual node found !")
     }
 
-    private fun getExistingVirtualIndex(physicalNode: Node): Int =
-        hashRing.values.count { it.isVirtualNodeOf(physicalNode) }
+    fun getExistingVirtualNodeCount(physicalNode: Node): Int = hashRing.values.count { it.isVirtualNodeOf(physicalNode) }
 
     fun getHashRingSize(): Int = hashRing.size
 }

--- a/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/consistenthashing/node/Instance.kt
+++ b/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/consistenthashing/node/Instance.kt
@@ -6,5 +6,20 @@ class Instance(
 
     override fun getKey(): String = ip
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Instance
+
+        if (ip != other.ip) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return ip.hashCode()
+    }
+
     override fun toString(): String = getKey()
 }

--- a/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/controllers/KeyValueProxyController.kt
+++ b/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/controllers/KeyValueProxyController.kt
@@ -1,8 +1,10 @@
 package com.tommy.proxy.controllers
 
+import com.tommy.proxy.dtos.FaultNodeRequest
 import com.tommy.proxy.dtos.KeyValueGetResponse
 import com.tommy.proxy.dtos.KeyValueSaveRequest
 import com.tommy.proxy.dtos.KeyValueSaveResponse
+import com.tommy.proxy.services.FaultNodeService
 import com.tommy.proxy.services.KeyValueProxyService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class KeyValueProxyController(
     private val keyValueProxyService: KeyValueProxyService,
+    private val faultNodeService: FaultNodeService,
 ) {
 
     @PostMapping("/")
@@ -27,5 +30,10 @@ class KeyValueProxyController(
         @RequestParam key: String,
     ): KeyValueGetResponse {
         return keyValueProxyService.get(key)
+    }
+
+    @PostMapping("/fault-node")
+    fun handlingFaultNode(@RequestBody faultNodeRequest: FaultNodeRequest) {
+        faultNodeService.handleFaultNode(faultNodeRequest)
     }
 }

--- a/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/dtos/FaultNodeRequest.kt
+++ b/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/dtos/FaultNodeRequest.kt
@@ -1,0 +1,10 @@
+package com.tommy.proxy.dtos
+
+class FaultNodeRequest(
+    val address: String,
+    val heatBeatCount: Int,
+) {
+    override fun toString(): String {
+        return "FaultNodeRequest(address='$address', heatBeatCount=$heatBeatCount)"
+    }
+}

--- a/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/exceptions/AlreadyProcessedLockException.kt
+++ b/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/exceptions/AlreadyProcessedLockException.kt
@@ -1,0 +1,3 @@
+package com.tommy.proxy.exceptions
+
+class AlreadyProcessedLockException(message: String) : RuntimeException(message)

--- a/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/exceptions/LockAcquisitionFailedException.kt
+++ b/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/exceptions/LockAcquisitionFailedException.kt
@@ -1,0 +1,3 @@
+package com.tommy.proxy.exceptions
+
+class LockAcquisitionFailedException(message: String) : RuntimeException(message)

--- a/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/exceptions/LockProcessFailedException.kt
+++ b/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/exceptions/LockProcessFailedException.kt
@@ -1,0 +1,3 @@
+package com.tommy.proxy.exceptions
+
+class LockProcessFailedException(message: String) : RuntimeException(message)

--- a/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/services/FaultNodeService.kt
+++ b/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/services/FaultNodeService.kt
@@ -1,0 +1,45 @@
+package com.tommy.proxy.services
+
+import com.tommy.proxy.consistenthashing.ConsistentHashRouter
+import com.tommy.proxy.consistenthashing.node.Instance
+import com.tommy.proxy.dtos.FaultNodeRequest
+import mu.KotlinLogging
+import org.redisson.api.RedissonClient
+import org.springframework.stereotype.Service
+import java.util.concurrent.TimeUnit
+
+@Service
+class FaultNodeService(
+    private val redissonClient: RedissonClient,
+    private val consistentHashRouter: ConsistentHashRouter,
+) {
+    private val logger = KotlinLogging.logger { }
+
+    fun handleFaultNode(faultNodeRequest: FaultNodeRequest) {
+        val lock = redissonClient.getLock(faultNodeRequest.address)
+
+        val available = lock.tryLock(5, 6, TimeUnit.SECONDS)
+        try {
+            if (!available) {
+                logger.info { "잠금 획득 실패!" }
+                logger.info { "$faultNodeRequest" }
+                return
+            }
+            val faultNode = Instance(faultNodeRequest.address)
+            val existingVirtualNodeCount = consistentHashRouter.getExistingVirtualNodeCount(faultNode)
+
+            if (existingVirtualNodeCount == 0) {
+                logger.info { "이미 처리된 잠금입니다." }
+                return
+            }
+            logger.info { "잠금 획득 ${Thread.currentThread()}" }
+
+            consistentHashRouter.removeNode(faultNode)
+            return
+        } catch (e: Exception) {
+            throw RuntimeException()
+        } finally {
+            lock.unlock()
+        }
+    }
+}

--- a/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/services/FaultNodeService.kt
+++ b/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/services/FaultNodeService.kt
@@ -3,6 +3,9 @@ package com.tommy.proxy.services
 import com.tommy.proxy.consistenthashing.ConsistentHashRouter
 import com.tommy.proxy.consistenthashing.node.Instance
 import com.tommy.proxy.dtos.FaultNodeRequest
+import com.tommy.proxy.exceptions.AlreadyProcessedLockException
+import com.tommy.proxy.exceptions.LockAcquisitionFailedException
+import com.tommy.proxy.exceptions.LockProcessFailedException
 import mu.KotlinLogging
 import org.redisson.api.RedissonClient
 import org.springframework.stereotype.Service
@@ -21,23 +24,20 @@ class FaultNodeService(
         val available = lock.tryLock(5, 6, TimeUnit.SECONDS)
         try {
             if (!available) {
-                logger.info { "잠금 획득 실패!" }
-                logger.info { "$faultNodeRequest" }
-                return
+                throw LockAcquisitionFailedException("잠금 획득 실패($faultNodeRequest)")
             }
             val faultNode = Instance(faultNodeRequest.address)
             val existingVirtualNodeCount = consistentHashRouter.getExistingVirtualNodeCount(faultNode)
 
             if (existingVirtualNodeCount == 0) {
-                logger.info { "이미 처리된 잠금입니다." }
-                return
+                throw AlreadyProcessedLockException("이미 처리된 요청($faultNodeRequest)")
             }
-            logger.info { "잠금 획득 ${Thread.currentThread()}" }
 
             consistentHashRouter.removeNode(faultNode)
             return
         } catch (e: Exception) {
-            throw RuntimeException()
+            logger.error { e }
+            throw LockProcessFailedException(e.message!!)
         } finally {
             lock.unlock()
         }

--- a/key-value-managed-proxy-server/src/test/kotlin/com/tommy/proxy/services/FaultNodeServiceIntegrationTest.kt
+++ b/key-value-managed-proxy-server/src/test/kotlin/com/tommy/proxy/services/FaultNodeServiceIntegrationTest.kt
@@ -1,0 +1,48 @@
+package com.tommy.proxy.services
+
+import com.tommy.proxy.consistenthashing.ConsistentHashRouter
+import com.tommy.proxy.consistenthashing.node.Instance
+import com.tommy.proxy.dtos.FaultNodeRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+
+@SpringBootTest
+class FaultNodeServiceIntegrationTest @Autowired constructor(
+    private val faultNodeService: FaultNodeService,
+    private val consistentHashRouter: ConsistentHashRouter,
+) {
+
+    @Test
+    fun `sut handle fault node when FaultNodeRequest is given`() {
+        // Arrange
+        val faultNodeRequest = FaultNodeRequest("http://localhost:8081", 1)
+
+        val threadCount = 4
+        val executorService = Executors.newFixedThreadPool(32)
+        val countDownLatch = CountDownLatch(threadCount)
+
+        assertThat(consistentHashRouter.getHashRingSize()).isEqualTo(40)
+        assertThat(consistentHashRouter.getExistingVirtualNodeCount(Instance(faultNodeRequest.address))).isEqualTo(10)
+
+        // Act
+        for (i in 0 until threadCount) {
+            executorService.submit {
+                try {
+                    faultNodeService.handleFaultNode(faultNodeRequest)
+                } finally {
+                    countDownLatch.countDown()
+                }
+            }
+        }
+
+        countDownLatch.await()
+
+        // Assert
+        assertThat(consistentHashRouter.getHashRingSize()).isEqualTo(30)
+        assertThat(consistentHashRouter.getExistingVirtualNodeCount(Instance(faultNodeRequest.address))).isZero
+    }
+}

--- a/key-value-managed-proxy-server/src/test/kotlin/com/tommy/proxy/services/FaultNodeServiceTest.kt
+++ b/key-value-managed-proxy-server/src/test/kotlin/com/tommy/proxy/services/FaultNodeServiceTest.kt
@@ -1,0 +1,99 @@
+package com.tommy.proxy.services
+
+import com.tommy.proxy.consistenthashing.ConsistentHashRouter
+import com.tommy.proxy.consistenthashing.node.Instance
+import com.tommy.proxy.dtos.FaultNodeRequest
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.justRun
+import io.mockk.verify
+import io.mockk.verifyAll
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.redisson.api.RLock
+import org.redisson.api.RedissonClient
+import java.util.concurrent.TimeUnit
+
+@ExtendWith(MockKExtension::class)
+class FaultNodeServiceTest(
+    @MockK private val redissonClient: RedissonClient,
+    @MockK private val lock: RLock,
+    @MockK private val consistentHashRouter: ConsistentHashRouter,
+) {
+    @InjectMockKs
+    private lateinit var sut: FaultNodeService
+
+    @Test
+    @DisplayName("실패한 노드 정보가 주어질 경우 해당 노드를 안정해시에서 제거한다.")
+    fun `sut handle fault node when FaultNodeRequest is given`() {
+        // Arrange
+        val faultNodeRequest = FaultNodeRequest("http://localhost:8081", 1)
+        val faultNode = Instance(faultNodeRequest.address)
+
+        every { redissonClient.getLock(faultNodeRequest.address) } returns lock
+        every { lock.tryLock(5, 6, TimeUnit.SECONDS) } returns true
+        every { consistentHashRouter.getExistingVirtualNodeCount(faultNode) } returns 1
+        justRun { consistentHashRouter.removeNode(faultNode) }
+        justRun { lock.unlock() }
+
+        // Act
+        sut.handleFaultNode(faultNodeRequest)
+
+        // Assert
+        verifyAll {
+            redissonClient.getLock(faultNodeRequest.address)
+            lock.tryLock(5, 6, TimeUnit.SECONDS)
+            consistentHashRouter.getExistingVirtualNodeCount(faultNode)
+            consistentHashRouter.removeNode(faultNode)
+            lock.unlock()
+        }
+    }
+
+    @Test
+    @DisplayName("이미 장애처리가 된 노드일 경우 Exception 을 발생한다.")
+    fun `sut throw an exception when already handled fault node`() {
+        // Arrange
+        val faultNodeRequest = FaultNodeRequest("http://localhost:8081", 1)
+        val faultNode = Instance(faultNodeRequest.address)
+
+        every { redissonClient.getLock(faultNodeRequest.address) } returns lock
+        every { lock.tryLock(5, 6, TimeUnit.SECONDS) } returns true
+        every { consistentHashRouter.getExistingVirtualNodeCount(faultNode) } returns 0
+        justRun { lock.unlock() }
+
+        // Act
+        sut.handleFaultNode(faultNodeRequest)
+
+        // Assert
+        verify { redissonClient.getLock(faultNodeRequest.address) }
+        verify { lock.tryLock(5, 6, TimeUnit.SECONDS) }
+        verify { consistentHashRouter.getExistingVirtualNodeCount(faultNode) }
+        verify(exactly = 0) { consistentHashRouter.removeNode(faultNode) }
+        verify { lock.unlock() }
+    }
+
+    @Test
+    @DisplayName("잠금을 획득하지 못했을 경우 Exception 을 발생한다.")
+    fun `sut throws an exception when lock not acquired`() {
+        // Arrange
+        val faultNodeRequest = FaultNodeRequest("http://localhost:8081", 1)
+        val faultNode = Instance(faultNodeRequest.address)
+
+        every { redissonClient.getLock(faultNodeRequest.address) } returns lock
+        every { lock.tryLock(5, 6, TimeUnit.SECONDS) } returns false
+        justRun { lock.unlock() }
+
+        // Act
+        sut.handleFaultNode(faultNodeRequest)
+
+        // Assert
+        redissonClient.getLock(faultNodeRequest.address)
+        verify { lock.tryLock(5, 6, TimeUnit.SECONDS) }
+        verify(exactly = 0) { consistentHashRouter.getExistingVirtualNodeCount(faultNode) }
+        verify(exactly = 0) { consistentHashRouter.removeNode(faultNode) }
+        verify { lock.unlock() }
+    }
+}


### PR DESCRIPTION
#### 장애가 발생한 노드의 VirtualNode 를 제거하는 기능 구현
* 잠금을 하는 구현체로 redisson 사용

#### 실패 처리 로직 Exception 보완
* 각 예외 케이스 발생 시 명확한 Exception 을 throw 한다.
* try-catch 시 고려하지 못한 케이스를 대비하여 LockProcessFailedException 를 설정하고, error log 를 찍는다.

work items: #31