### PR TITLE
장애 감지 시 원본 해시링을 복제하여 데이터 동기화 처리

### DIFF
--- a/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/services/FaultNodeService.kt
+++ b/key-value-managed-proxy-server/src/main/kotlin/com/tommy/proxy/services/FaultNodeService.kt
@@ -32,7 +32,7 @@ class FaultNodeService(
             if (existingVirtualNodeCount == 0) {
                 throw AlreadyProcessedLockException("이미 처리된 요청($faultNodeRequest)")
             }
-
+            consistentHashRouter.replicateHashRing()
             consistentHashRouter.removeNode(faultNode)
             return
         } catch (e: Exception) {

--- a/key-value-managed-proxy-server/src/test/kotlin/com/tommy/proxy/consistenthashing/ConsistentHashRouterTest.kt
+++ b/key-value-managed-proxy-server/src/test/kotlin/com/tommy/proxy/consistenthashing/ConsistentHashRouterTest.kt
@@ -111,4 +111,18 @@ class ConsistentHashRouterTest {
         // 두 번째 가까운 노드의 정보: VirtualNode(physicalNode=http://localhost:8081, virtualIndex=9)
         assertThat(actual.getKey()).isEqualTo("http://localhost:8081")
     }
+
+    @Test
+    @DisplayName("원본 해시링을 복제하여 데이터를 동기화한다.")
+    fun `replicate hash ring`() {
+        // Arrange
+
+        // Act
+        sut.replicateHashRing()
+        sut.removeNode(Instance("http://localhost:8081"))
+
+        // Assert
+        assertThat(sut.getHashRingSize()).isEqualTo(30)
+        assertThat(sut.replicaHashRing.size).isEqualTo(40)
+    }
 }

--- a/key-value-managed-proxy-server/src/test/kotlin/com/tommy/proxy/services/FaultNodeServiceTest.kt
+++ b/key-value-managed-proxy-server/src/test/kotlin/com/tommy/proxy/services/FaultNodeServiceTest.kt
@@ -38,6 +38,7 @@ class FaultNodeServiceTest(
         every { redissonClient.getLock(faultNodeRequest.address) } returns lock
         every { lock.tryLock(5, 6, TimeUnit.SECONDS) } returns true
         every { consistentHashRouter.getExistingVirtualNodeCount(faultNode) } returns 1
+        justRun { consistentHashRouter.replicateHashRing() }
         justRun { consistentHashRouter.removeNode(faultNode) }
         justRun { lock.unlock() }
 
@@ -49,6 +50,7 @@ class FaultNodeServiceTest(
             redissonClient.getLock(faultNodeRequest.address)
             lock.tryLock(5, 6, TimeUnit.SECONDS)
             consistentHashRouter.getExistingVirtualNodeCount(faultNode)
+            consistentHashRouter.replicateHashRing()
             consistentHashRouter.removeNode(faultNode)
             lock.unlock()
         }


### PR DESCRIPTION
* 장애 감지 시 원본 해시링을 복제한다. 그리고 장애가 발생한 노드를 제외하여 다른 노드로 요청이 가도록 처리한다.
* 이는 노드가 복구됐을 때 데이터 일관성을 처리하는 수단이 되도록한다.

work items: #34